### PR TITLE
Only use WebPage images from JSON-LD

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
+/.idea
 /build
-/vendor
 /composer.json
 /composer.lock
+/vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+-   Extracting only web page images.
+
 ## [1.0.2] - 2021-02-20
 
 ### Changed

--- a/composer.lock
+++ b/composer.lock
@@ -4006,6 +4006,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <file name="tests/Extractor/ScanTestCasesTrait.php"/>
         </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/Extractor/ImageExtractor.php
+++ b/src/Extractor/ImageExtractor.php
@@ -42,17 +42,25 @@ SELECTOR;
         }
 
         $nodes = $graph->getNodes();
-        if (isset($nodes[0])) {
-            $images = $nodes[0]->getProperty('http://schema.org/image');
-            if ($images instanceof JsonLD\NodeInterface) {
-                $images = [$images];
-            }
+        foreach ($nodes as $node) {
+            // dump($node->getId());
+            // dump($node->getType());
+            $type = $node->getType();
+            if ($type instanceof JsonLD\NodeInterface) {
+                if ($type->getId() === 'http://schema.org/WebPage') {
+                    $images = $node->getProperty('http://schema.org/primaryImageOfPage');
 
-            /** @var JsonLD\NodeInterface $image */
-            foreach ($images ?? [] as $image) {
-                $url = $image->getProperty('http://schema.org/url');
-                if ($url instanceof JsonLD\NodeInterface) {
-                    return $url->getId();
+                    if ($images instanceof JsonLD\NodeInterface) {
+                        $images = [$images];
+                    }
+
+                    /** @var JsonLD\NodeInterface $image */
+                    foreach ($images ?? [] as $image) {
+                        $url = $image->getProperty('http://schema.org/url');
+                        if ($url instanceof JsonLD\NodeInterface) {
+                            return $url->getId();
+                        }
+                    }
                 }
             }
         }

--- a/test.php
+++ b/test.php
@@ -1,0 +1,9 @@
+<?php
+
+include 'vendor/autoload.php';
+
+$extractor = new \Extractum\Extractor('de');
+$html = file_get_contents(__DIR__.'/tests/Extractor/_tests/image/003.html');
+$essence = $extractor->extract($html, 'https:/example.com');
+
+dump($essence);

--- a/tests/Extractor/ImageExtractorTest.php
+++ b/tests/Extractor/ImageExtractorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the markuspoerschke/extractum package.
+ *
+ * (c) 2021 Markus Poerschke <markus@poerschke.nrw>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Extractum\Test\Extractor;
+
+use Extractum\Extractor\ImageExtractor;
+use Extractum\Helper\ExtractJsonLdTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+class ImageExtractorTest extends TestCase
+{
+    use ExtractJsonLdTrait;
+    use ScanTestCasesTrait;
+
+    /**
+     * @dataProvider provideTestData
+     */
+    public function testImageIsExtracted(string $html, $expected): void
+    {
+        $crawler = new Crawler($html, 'https://www.example.com');
+        $actual = (new ImageExtractor())->extract($crawler, $this->extractJsonLd($crawler));
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function provideTestData(): iterable
+    {
+        yield from $this->scanForTestCases(__DIR__ . '/_tests/image');
+    }
+}

--- a/tests/Extractor/_tests/image/001.html
+++ b/tests/Extractor/_tests/image/001.html
@@ -1,0 +1,5 @@
+<html>
+    <!-- No image in this HTML document -->
+    <head></head>
+    <body></body>
+</html>

--- a/tests/Extractor/_tests/image/001.php
+++ b/tests/Extractor/_tests/image/001.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the markuspoerschke/extractum package.
+ *
+ * (c) 2021 Markus Poerschke <markus@poerschke.nrw>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+return null;

--- a/tests/Extractor/_tests/image/002.html
+++ b/tests/Extractor/_tests/image/002.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <meta
+            property="og:image"
+            content="https://cdn.example.com/image.jpeg"
+        />
+    </head>
+</html>

--- a/tests/Extractor/_tests/image/002.php
+++ b/tests/Extractor/_tests/image/002.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the markuspoerschke/extractum package.
+ *
+ * (c) 2021 Markus Poerschke <markus@poerschke.nrw>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+return 'https://cdn.example.com/image.jpeg';

--- a/tests/Extractor/_tests/image/003.html
+++ b/tests/Extractor/_tests/image/003.html
@@ -1,0 +1,67 @@
+<html>
+    <head>
+        <meta
+            property="og:image"
+            content="https://cdn.example.com/image-from-meta-tag.jpeg"
+        />
+
+        <script type="application/ld+json" class="yoast-schema-graph">
+            {
+                "@context": "https://schema.org",
+                "@graph": [
+                    {
+                        "@type": "Organization",
+                        "@id": "https://example.com/#organization",
+                        "name": "Example Inc.",
+                        "logo": {
+                            "@type": "ImageObject",
+                            "@id": "https://example.com/#logo",
+                            "inLanguage": "de-DE",
+                            "url": "https://example.com/logo.png",
+                            "contentUrl": "https://example.com/logo.png",
+                            "width": 300,
+                            "height": 78,
+                            "caption": "Example Inc."
+                        },
+                        "image": {
+                            "@id": "https://example.com/#logo"
+                        }
+                    },
+                    {
+                        "@type": "WebSite",
+                        "@id": "https://example.com/#website",
+                        "url": "https://example.com/",
+                        "name": "Example",
+                        "publisher": {
+                            "@id": "https://example.com/#organization"
+                        },
+                        "inLanguage": "de-DE"
+                    },
+                    {
+                        "@type": "ImageObject",
+                        "@id": "https://example.com/website/#primaryimage",
+                        "inLanguage": "de-DE",
+                        "url": "https://example.com/website-image.png",
+                        "contentUrl": "https://example.com/website-image.png",
+                        "width": 1080,
+                        "height": 810
+                    },
+                    {
+                        "@type": "WebPage",
+                        "@id": "https://example.com/webpage/#webpage",
+                        "url": "https://example.com/webpage/",
+                        "isPartOf": {
+                            "@id": "https://example.com/#website"
+                        },
+                        "primaryImageOfPage": {
+                            "@id": "https://example.com/website/#primaryimage"
+                        },
+                        "datePublished": "2021-07-22T12:00:28+00:00",
+                        "dateModified": "2021-07-22T12:00:47+00:00",
+                        "inLanguage": "de-DE"
+                    }
+                ]
+            }
+        </script>
+    </head>
+</html>

--- a/tests/Extractor/_tests/image/003.php
+++ b/tests/Extractor/_tests/image/003.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the markuspoerschke/extractum package.
+ *
+ * (c) 2021 Markus Poerschke <markus@poerschke.nrw>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+return 'https://example.com/website-image.png';


### PR DESCRIPTION
Avoid that any other image that do not belong to the WebPage are extracted. A mistake in the current implementation was, that the image of the organization was extracted instead.